### PR TITLE
fix(zsh): tab completion hangs

### DIFF
--- a/cachyos-config.zsh
+++ b/cachyos-config.zsh
@@ -18,6 +18,9 @@ ENABLE_CORRECTION="true"
 # Uncomment the following line to display red dots whilst waiting for completion.
 COMPLETION_WAITING_DOTS="true"
 
+# Fix hanging tab completion on directories
+CASE_SENSITIVE="true"
+
 # Which plugins would you like to load?
 # Standard plugins can be found in $ZSH/plugins/
 # Custom plugins may be added to $ZSH_CUSTOM/plugins/


### PR DESCRIPTION
When attempting to tab complete on directories, it will hang and lockup the current terminal emulator session. With this in place, this no longer happens.