### PR TITLE
fix: use HISTORY_IGNORE for zsh shell

### DIFF
--- a/cachyos-config.zsh
+++ b/cachyos-config.zsh
@@ -39,7 +39,7 @@ export HISTCONTROL=ignoreboth
 
 # Don't add certain commands to the history file.
 
-export HISTIGNORE="&:[bf]g:c:clear:history:exit:q:pwd:* --help"
+export HISTORY_IGNORE="(\&|[bf]g|c|clear|history|exit|q|pwd|* --help)"
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 


### PR DESCRIPTION
The zsh shell doesn't use the `HISTIGNORE` environment variable. Instead, it has a `HISTORY_IGNORE` environment variable.

See: https://zsh.sourceforge.io/Doc/Release/Parameters.html#Parameters-Used-By-The-Shell