### PR TITLE
fix: prevent pacman from running on shell startup

### DIFF
--- a/cachyos-config.zsh
+++ b/cachyos-config.zsh
@@ -77,7 +77,9 @@ alias please="sudo"
 alias tb="nc termbin.com 9999"
 
 # Cleanup orphaned packages
-alias cleanup="sudo pacman -Rsn $(pacman -Qtdq)"
+cleanup() {
+  sudo pacman -Rsn $(pacman -Qtdq)
+}
 
 # Get the error messages from journalctl
 alias jctl="journalctl -p 3 -xb"


### PR DESCRIPTION
The cleanup alias use double quotes, causing command substitution
(pacman -Qtdq) to execute during shell startup.

This results in slow initialization.

Fixed by replacing with function.

Fixes https://github.com/CachyOS/cachyos-zsh-config/issues/14 