### PR TITLE
Add fastfetch as welcome message

### DIFF
--- a/cachyos-config.zsh
+++ b/cachyos-config.zsh
@@ -1,3 +1,6 @@
+## Run fastfetch as welcome message
+(( $+commands[fastfetch] )) && fastfetch
+
 # Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
 # Initialization code that may require console input (password prompts, [y/n]
 # confirmations, etc.) must go above this block; everything else may go below.


### PR DESCRIPTION
Add fastfetch command as a welcome message in Zsh config

<img width="1103" height="770" alt="image" src="https://github.com/user-attachments/assets/f6cd9350-7662-42bd-b17e-248478f04680" />


To be exactly on-par with https://github.com/CachyOS/cachyos-fish-config/blob/main/cachyos-config.fish#L1-L2

also please note that fast fetch absolutely needs to be executed before the p10k block
```shell
# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.
# Initialization code that may require console input (password prompts, [y/n]
# confirmations, etc.) must go above this block; everything else may go below.
if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
fi
```
otherwise, p10k issue the following warning:

```
[WARNING]: Console output during zsh initialization detected.

When using Powerlevel10k with instant prompt, console output during zsh
initialization may indicate issues.

You can:

  - Recommended: Change ~/.zshrc so that it does not perform console I/O
    after the instant prompt preamble. See the link below for details.

    * You will not see this error message again.
    * Zsh will start quickly and prompt will update smoothly.

  - Suppress this warning either by running p10k configure or by manually
    defining the following parameter:

      typeset -g POWERLEVEL9K_INSTANT_PROMPT=quiet

    * You will not see this error message again.
    * Zsh will start quickly but prompt will jump down after initialization.

  - Disable instant prompt either by running p10k configure or by manually
    defining the following parameter:

      typeset -g POWERLEVEL9K_INSTANT_PROMPT=off

    * You will not see this error message again.
    * Zsh will start slowly.

  - Do nothing.

    * You will see this error message every time you start zsh.
    * Zsh will start quickly but prompt will jump down after initialization.

For details, see:
https://github.com/romkatv/powerlevel10k#instant-prompt
```

I simply went with p10k's recommendation: to change .zshrc so that it does not perform console I/O after the instant prompt preamble. This is why the fastfetch line is on top.
